### PR TITLE
Add generator for large datasets

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -677,6 +677,33 @@ class Client
 
         return array('success' => true, 'data' => $collection);
     }
+    
+    /*
+     * Yield all results from the API
+     */
+    public function getResultGenerator($entity, $filters = array())
+    {
+        $gotAll = false;
+
+        $functionname = 'get' . ucfirst($entity) . 's';
+
+        $i = 0;
+        while ($gotAll == false) {
+            $filters['offset'] = ($i * 100);
+            $result = $this->$functionname($filters);
+            if (isset($result['success']) && $result['success'] && isset($result['data'])) {
+                if (count($result['data']) < 100) {
+                    $gotAll = true;
+                }
+                foreach ($result['data'] as $item) {
+                    yield $item;
+                }
+                $i++;
+            } else {
+                throw new Exception("Invalid API response: " . json_encode($result));
+            }
+        }
+    }
 
     /**
      * Creates a new company account for Picqer


### PR DESCRIPTION
By using `yield`, we can use the results directly, before waiting for the batch to finish. This helps reduce memory usage and reduces the rate of the request. Eg. load 100 results, process 1 by 1, load another 100 requests, process those etc.

It can still just be used in a foreach, without doing anything different.