### PR TITLE
Account for RateLimits in getAllResults method

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -692,6 +692,7 @@ class Client
         $functionname = 'get' . ucfirst($entity) . 's';
 
         $i = 0;
+        $startTime = time();
         while ($gotAll == false) {
             $filters['offset'] = ($i * 100);
             $result = $this->$functionname($filters);
@@ -701,6 +702,9 @@ class Client
                 }
                 foreach ($result['data'] as $item) {
                     $collection[] = $item;
+                }
+                if ($result['rate-limit-remaining'] === 0) {
+                    sleep(60 - ((time() - $startTime) % 60));
                 }
                 $i++;
             } else {


### PR DESCRIPTION
This sleep function should make sure that whenever the ratelimit is reached it'll wait till a new request can be made, maybe add this as a parameter to allow the developer using this to turn it off or on?