### PR TITLE
Flush response headers

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -232,7 +232,7 @@ class Client
     public function updateProductPartAmount($idproduct, $idproductpart, $amount)
     {
         $params = ['amount' => $amount];
-        
+
         return $this->sendRequest('/products/' . $idproduct . '/parts/'.$idproductpart, $params, self::METHOD_PUT);
     }
 
@@ -497,7 +497,7 @@ class Client
     {
         return $this->sendRequest('/suppliers', null, null, $filters);
     }
-    
+
     public function getAllSuppliers($filters = [])
     {
         return $this->getAllResults('supplier', $filters);
@@ -699,7 +699,7 @@ class Client
     {
         return $this->sendRequest('/tags', [], self::METHOD_GET, $filters);
     }
-    
+
     public function getAllTags($filters = [])
     {
         return $this->getAllResults('tag', $filters);
@@ -763,7 +763,7 @@ class Client
     {
         return $this->sendRequest('/backorders/process', null, self::METHOD_POST);
     }
-    
+
     public function deleteBackorder($idbackorder)
     {
         return $this->sendRequest('/backorders/' . $idbackorder, null, self::METHOD_DELETE);
@@ -807,7 +807,7 @@ class Client
     {
         return $this->sendRequest('/shippingproviders');
     }
-    
+
     /*
      * Product fields
      */
@@ -820,7 +820,7 @@ class Client
     {
         return $this->sendRequest('/productfields/' . $idproductfield);
     }
-    
+
     /*
      * Order fields
      */
@@ -833,7 +833,7 @@ class Client
     {
         return $this->sendRequest('/orderfields/' . $idorderfield);
     }
-    
+
     /*
      * Customer fields
      */
@@ -953,7 +953,7 @@ class Client
 
         return ['success' => true, 'data' => $collection];
     }
-    
+
     /*
      * Yield all results from the API
      */
@@ -1051,6 +1051,7 @@ class Client
     public function sendRequest($endpoint, $params = [], $method = self::METHOD_GET, $filters = [])
     {
         $endpoint = $this->getEndpoint($endpoint, $filters);
+
         $this->debug('URL: ' . $this->getUrl($endpoint));
 
         $curlSession = curl_init();
@@ -1073,6 +1074,7 @@ class Client
 
         $this->setPostData($curlSession, $method, $params);
         $this->setSslVerification($curlSession);
+        $this->resetRawResponseHeaders();
 
         $apiResult = curl_exec($curlSession);
         $headerInfo = curl_getinfo($curlSession);
@@ -1169,6 +1171,11 @@ class Client
         }
 
         return $parsedHeaders;
+    }
+
+    protected function resetRawResponseHeaders()
+    {
+        $this->rawResponseHeaders = [];
     }
 
     protected function getRemainingRateLimit(array $apiResultHeaders)

--- a/src/Client.php
+++ b/src/Client.php
@@ -1074,7 +1074,6 @@ class Client
 
         $this->setPostData($curlSession, $method, $params);
         $this->setSslVerification($curlSession);
-        $this->resetRawResponseHeaders();
 
         $apiResult = curl_exec($curlSession);
         $headerInfo = curl_getinfo($curlSession);
@@ -1083,6 +1082,7 @@ class Client
 
         $apiResultJson = json_decode($apiResult, true);
         $apiResultHeaders = $this->parseRawHeaders();
+        $this->resetRawHeaders();
 
         $result = [];
         $result['success'] = false;
@@ -1173,7 +1173,7 @@ class Client
         return $parsedHeaders;
     }
 
-    protected function resetRawResponseHeaders()
+    protected function resetRawHeaders()
     {
         $this->rawResponseHeaders = [];
     }


### PR DESCRIPTION
When performing an HTTP request, we store the response headers in an internal array in the client (`rawResponseHeaders`). This is done to parse them at a later point.

This array is not reset when sending a new request. When a client is used for a long time, this will cause the array to keep growing with each received response header. This could cause PHP processes to run out of memory in, for example, long running processes reusing the same client instance.

This bug did not cause any issues related to rate limiting, since the headers were overwritten if they occurred more than once in the response headers array.