### PR TITLE
Fix deprecated warnings for dynamic property creation

### DIFF
--- a/src/PicqerWebhook.php
+++ b/src/PicqerWebhook.php
@@ -15,6 +15,7 @@ class PicqerWebhook
     protected $event;
     protected $data;
     protected $event_triggered_at;
+    protected $rawPayload;
 
     public function __construct($webhookPayload)
     {


### PR DESCRIPTION
This PR addresses deprecated warnings related to the dynamic property `Picqer\Api\PicqerWebhook::$rawPayload`. The warnings, such as:

```
PHP Deprecated: Deprecated: Creation of dynamic property Picqer\Api\PicqerWebhook::$rawPayload is deprecated (0) in /var/www/html/vendor/picqer/api-client/src/PicqerWebhook.php:21
```

occurred because `$rawPayload` was being dynamically created. This PR resolves the issue by explicitly declaring the `$rawPayload` property in the `PicqerWebhook` class to prevent these warnings.