### PR TITLE
Add filters to getProductsOnLocation for pagination

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -1018,9 +1018,9 @@ class Client
         return $this->sendRequest('/locations/' . $id, [], self::METHOD_DELETE);
     }
 
-    public function getProductsOnLocation($id)
+    public function getProductsOnLocation($id, $filters = [])
     {
-        return $this->sendRequest('/locations/' . $id . '/products', [], self::METHOD_GET);
+        return $this->sendRequest('/locations/' . $id . '/products', [], self::METHOD_GET, $filters);
     }
 
     /*


### PR DESCRIPTION
Hey Picqer Team,

not sure if you take PRs, but this was a small issue I ran in today. 
With moving all our inventory, we now have some containers with > 100 skus. 
The results are paginated, but the SDK did not implement a way to apply the pagination, so I could only get the first 100 products on this container/location.

Hope this is possible to merge. Let me know if anything!